### PR TITLE
Nvidia gpu monitoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
 OPTION(PROFILE_ENABLED "Whether library performs profiling operations or does nothing" ON)
 OPTION(SAMPLE_ENABLED "Whether sample binary is built or not" OFF)
 OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON)
+OPTION(GPU_MONITOR_NVIDIA "Whether NVidiaMonitor class for monitoring NVidia GPUs is compiled and embedded to the library" OFF)
 
 ADD_SUBDIRECTORY(lib)
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ uprofile::start("uprofile.log");
 uprofile::startGPUMemoryMonitoring(200);
 ```
 
+#### Supported GPU monitoring
+
+Here is the list of GPUs supported by `cppuprofile`
+
+* NVidia Graphics Cards (through `nvidia-smi`). Pass `-DGPU_MONITOR_NVIDIA` as compile option and inject `uprofile::NvidiaMonitor` from `<cppuprofile/monitors/nvidiamonitor` as `GPUMonitor`. The `nvidia-smi` tool should be installed into `/usr/bin` directory.
+
 ## Tools
 
 The project also brings a tool for displaying the different metrics in

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -37,18 +37,23 @@ SET(UProfile_PUBLIC_HEADERS
     igpumonitor.h
 )
 
-SET(UProfile_HEADERS
-    ${UProfile_PUBLIC_HEADERS}
-    uprofileimpl.h
-    util/timer.h
-    util/cpumonitor.h
-)
-
 SET(UProfile_IMPL
     uprofile.cpp
     uprofileimpl.cpp
     util/timer.cpp
     util/cpumonitor.cpp
+)
+
+IF(GPU_MONITOR_NVIDIA)
+   LIST(APPEND UProfile_PUBLIC_HEADERS monitors/nvidiamonitor.h)
+   LIST(APPEND UProfile_IMPL monitors/nvidiamonitor.cpp)
+ENDIF()
+
+SET(UProfile_HEADERS
+    ${UProfile_PUBLIC_HEADERS}
+    uprofileimpl.h
+    util/timer.h
+    util/cpumonitor.h
 )
 
 SET(UProfile_SRCS

--- a/lib/igpumonitor.h
+++ b/lib/igpumonitor.h
@@ -10,7 +10,8 @@
 #ifndef IGPUMONITOR_H_
 #define IGPUMONITOR_H_
 
-namespace uprofile {
+namespace uprofile
+{
 
 /**
  * Interface to implement for monitoring GPU usage and memory
@@ -20,14 +21,20 @@ namespace uprofile {
  * be defined to retrieve metrics from GPU vendor (Nvidia, AMD, Broadcom
  * for RPI...)
  */
-class IGPUMonitor {
+class IGPUMonitor
+{
 public:
-	virtual ~IGPUMonitor() {}
+    virtual ~IGPUMonitor() {}
 
-	// Usage should be in percentage
-	virtual float getUsage() = 0;
-	// usedMem and totalMem should be returned as KiB
-	virtual void getMemory(int& usedMem, int& totalMem) = 0;
+    // Start monitoring
+    virtual void start(int period) = 0;
+    // Stop monitoring
+    virtual void stop() = 0;
+
+    // Usage should be in percentage
+    virtual float getUsage() = 0;
+    // usedMem and totalMem should be returned as KiB
+    virtual void getMemory(int& usedMem, int& totalMem) = 0;
 };
 
 }

--- a/lib/monitors/nvidiamonitor.cpp
+++ b/lib/monitors/nvidiamonitor.cpp
@@ -1,0 +1,163 @@
+// Software Name : cppuprofile
+// SPDX-FileCopyrightText: Copyright (c) 2023 Orange
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// This software is distributed under the BSD License;
+// see the LICENSE file for more details.
+//
+// Author: Cédric CHEDALEUX <cedric.chedaleux@orange.com> et al.
+
+#include "nvidiamonitor.h"
+
+#include <algorithm>
+#include <errno.h>
+#include <fcntl.h>
+#include <iostream>
+#include <sstream>
+#include <string.h>
+
+#if defined(__linux__)
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+const string errorMsg = "Failed to monitor nvidia-smi process";
+
+#if defined(__linux__)
+int read_nvidia_smi_stdout(int fd, string& gpuUsage, string& usedMem, string& totalMem)
+{
+    string line;
+    while (line.find('\n') == string::npos) { // full line read
+        char buffer[4096];
+        ssize_t count = read(fd, buffer, sizeof(buffer)); // if child process crashes, we gonna be blocked here forever
+        if (count == -1) {
+            return errno;
+        } else if (count > 0) { // there is something to read
+            line += string(buffer, count);
+        }
+    }
+
+    // Remove colon to have only spaces and use istringstream
+    line.erase(remove(line.begin(), line.end(), ','), line.end());
+    std::istringstream ss(line);
+    ss >> gpuUsage >> usedMem >> totalMem;
+
+    return 0;
+}
+#endif
+
+uprofile::NvidiaMonitor::NvidiaMonitor()
+{
+}
+
+uprofile::NvidiaMonitor::~NvidiaMonitor()
+{
+    stop();
+}
+
+void uprofile::NvidiaMonitor::start(int period)
+{
+    watchGPU(period);
+}
+
+void uprofile::NvidiaMonitor::stop()
+{
+    abortWatchGPU();
+}
+
+float uprofile::NvidiaMonitor::getUsage()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_gpuUsage;
+}
+
+void uprofile::NvidiaMonitor::getMemory(int& usedMem, int& totalMem)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    usedMem = m_usedMem;
+    totalMem = m_totalMem;
+}
+
+void uprofile::NvidiaMonitor::watchGPU(int period)
+{
+    if (m_watching) {
+        return;
+    }
+
+#if defined(__linux__)
+    char* args[5];
+    args[0] = (char*)"/usr/bin/nvidia-smi";
+    string period_arg = "-lms=" + to_string(period); // lms stands for continuous watching
+    args[1] = (char*)period_arg.c_str();
+    args[2] = (char*)"--query-gpu=utilization.gpu,memory.used,memory.total";
+    args[3] = (char*)"--format=csv,noheader,nounits";
+    args[4] = NULL;
+    string output;
+    int pipes[2];
+
+    // Create the pipe
+    if (pipe(pipes) == -1) {
+        cerr << errorMsg << ": pipe creation failed" << endl;
+        return;
+    }
+
+    // Create a child process for calling nvidia-smi
+    pid_t pid = fork();
+
+    switch (pid) {
+    case -1: /* Error */
+        cerr << errorMsg << ": process fork failed" << endl;
+        return;
+    case 0: /* We are in the child process */
+        while ((dup2(pipes[1], STDOUT_FILENO) == -1) && (errno == EINTR)) {
+        }
+        close(pipes[1]);
+        close(pipes[0]);
+        execv(args[0], args);
+        cerr << "Failed to execute '" << args[0] << "': " << strerror(errno) << endl; /* execl doesn't return unless there's an error */
+        exit(1);
+    default: /* We are in the parent process */
+        int stdout_fd = pipes[0];
+
+        // Start a thread to retrieve the child process stdout
+        m_watching = true;
+        m_watcherThread = unique_ptr<std::thread>(new thread([stdout_fd, pid, this]() {
+            while (shouldWatch()) {
+                string gpuUsage, usedMem, totalMem;
+                // if the child process crashes, an error is raised here and threads ends up
+                int err = read_nvidia_smi_stdout(stdout_fd, gpuUsage, usedMem, totalMem);
+                if (err != 0) {
+                    cerr << errorMsg << ": read_error = " << strerror(err) << endl;
+                    break;
+                }
+                m_mutex.lock();
+                m_gpuUsage = !gpuUsage.empty() ? stof(gpuUsage) : 0.f;
+                m_usedMem = !usedMem.empty() ? stoi(usedMem) * 1024 : 0;    // MiB to KiB
+                m_totalMem = !totalMem.empty() ? stoi(totalMem) * 1024 : 0; // MiB to KiB
+                m_mutex.unlock();
+            }
+        }));
+    }
+#else
+    cerr << errorMsg << endl;
+#endif
+}
+
+void uprofile::NvidiaMonitor::abortWatchGPU()
+{
+#if defined(__linux__)
+    if (m_watcherThread) {
+        m_mutex.lock();
+        m_watching = false;
+        m_mutex.unlock();
+        m_watcherThread->join();
+        m_watcherThread.reset();
+    }
+#endif
+}
+
+bool uprofile::NvidiaMonitor::shouldWatch()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_watching;
+}

--- a/lib/monitors/nvidiamonitor.h
+++ b/lib/monitors/nvidiamonitor.h
@@ -1,0 +1,48 @@
+// Software Name : cppuprofile
+// SPDX-FileCopyrightText: Copyright (c) 2023 Orange
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// This software is distributed under the BSD License;
+// see the LICENSE file for more details.
+//
+// Author: Cédric CHEDALEUX <cedric.chedaleux@orange.com> et al.
+
+#ifndef NVIDIAMONITOR_H_
+#define NVIDIAMONITOR_H_
+
+#include "igpumonitor.h"
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace std;
+
+namespace uprofile
+{
+class NvidiaMonitor : public IGPUMonitor
+{
+public:
+    explicit NvidiaMonitor();
+    virtual ~NvidiaMonitor();
+
+    void start(int period) override;
+    void stop() override;
+    float getUsage() override;
+    void getMemory(int& usedMem, int& totalMem) override;
+
+private:
+    void watchGPU(int period);
+    void abortWatchGPU();
+    bool shouldWatch();
+
+    std::mutex m_mutex;
+    std::unique_ptr<std::thread> m_watcherThread;
+    bool m_watching = false;
+    int m_totalMem = 0;
+    int m_usedMem = 0;
+    float m_gpuUsage = 0.f;
+};
+
+}
+#endif /* NVIDIAMONITOR_H_ */

--- a/lib/uprofileimpl.cpp
+++ b/lib/uprofileimpl.cpp
@@ -141,6 +141,8 @@ void UProfileImpl::startGPUUsageMonitoring(int period)
         return;
     }
 
+    m_gpuMonitor->start(period);
+
     m_gpuUsageMonitorTimer.setInterval(period);
     m_gpuUsageMonitorTimer.setTimeout([=]() {
         dumpGpuUsage();
@@ -154,6 +156,7 @@ void UProfileImpl::startGPUMemoryMonitoring(int period)
         std::cerr << "Cannot monitor GPU memory: no GPUMonitor set!" << std::endl;
         return;
     }
+    m_gpuMonitor->start(period);
 
     m_gpuMemoryMonitorTimer.setInterval(period);
     m_gpuMemoryMonitorTimer.setTimeout([=]() {
@@ -216,6 +219,7 @@ void UProfileImpl::stop()
     m_cpuMonitorTimer.stop();
     m_gpuUsageMonitorTimer.stop();
     m_gpuMemoryMonitorTimer.stop();
+    m_gpuMonitor->stop();
     m_file.close();
 }
 

--- a/lib/uprofileimpl.cpp
+++ b/lib/uprofileimpl.cpp
@@ -211,7 +211,11 @@ vector<float> UProfileImpl::getInstantCpuUsage()
 
 void UProfileImpl::stop()
 {
+    m_processMemoryMonitorTimer.stop();
+    m_systemMemoryMonitorTimer.stop();
     m_cpuMonitorTimer.stop();
+    m_gpuUsageMonitorTimer.stop();
+    m_gpuMemoryMonitorTimer.stop();
     m_file.close();
 }
 

--- a/lib/util/timer.h
+++ b/lib/util/timer.h
@@ -14,6 +14,7 @@
 #include <functional>
 #include <iostream>
 #include <thread>
+#include <mutex>
 
 using namespace std;
 
@@ -27,11 +28,13 @@ public:
     void setInterval(int interval);
     void start();
     void stop();
+    bool isRunning();
 
 private:
     thread* m_th;
     bool m_running;
     int m_interval;
+    std::mutex m_mutex;
     std::function<void(void)> m_timeout;
 };
 


### PR DESCRIPTION
This branch adds a few robustness fixes:
* concurrent variable accesses in timer object
* stop all timers when stopping uprofile monitoring

It also implements `NvidiaMonitor` for monitoring NVidia GPU cards on Linux through `nvidia-smi` tool.