### PR TITLE
lib/nvidiamonitor: fix methods not exported in the symbol table

### DIFF
--- a/lib/api.h
+++ b/lib/api.h
@@ -1,0 +1,31 @@
+// Software Name : cppuprofile
+// SPDX-FileCopyrightText: Copyright (c) 2023 Orange
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// This software is distributed under the BSD License;
+// see the LICENSE file for more details.
+//
+// Author: Cédric CHEDALEUX <cedric.chedaleux@orange.com> et al.
+
+#pragma once
+
+// UPROFAPI is used to export public API functions from the DLL / shared library.
+#if defined(_UPROFILE_BUILD_SHARED)
+#if defined(_WIN32)
+/* Build as a Win32 DLL */
+#define UPROFAPI __declspec(dllexport)
+#elif defined(__linux__)
+/* Build as a shared library */
+#define UPROFAPI __attribute__((visibility("default")))
+#endif // if defined(_UPROFILE_BUILD_SHARED)
+
+#elif defined(UPROFILE_DLL)
+#if defined(_WIN32)
+/* Call uprofile as a Win32 DLL */
+#define UPROFAPI __declspec(dllimport)
+#endif // if defined(_WIN32)
+#endif // if defined(UPROFILE_DLL)
+
+#if !defined(UPROFAPI)
+#define UPROFAPI
+#endif

--- a/lib/monitors/nvidiamonitor.h
+++ b/lib/monitors/nvidiamonitor.h
@@ -11,6 +11,7 @@
 #define NVIDIAMONITOR_H_
 
 #include "igpumonitor.h"
+#include "api.h"
 #include <mutex>
 #include <string>
 #include <thread>
@@ -23,13 +24,13 @@ namespace uprofile
 class NvidiaMonitor : public IGPUMonitor
 {
 public:
-    explicit NvidiaMonitor();
-    virtual ~NvidiaMonitor();
+    UPROFAPI explicit NvidiaMonitor();
+    UPROFAPI virtual ~NvidiaMonitor();
 
-    void start(int period) override;
-    void stop() override;
-    float getUsage() override;
-    void getMemory(int& usedMem, int& totalMem) override;
+    UPROFAPI void start(int period) override;
+    UPROFAPI void stop() override;
+    UPROFAPI float getUsage() override;
+    UPROFAPI void getMemory(int& usedMem, int& totalMem) override;
 
 private:
     void watchGPU(int period);

--- a/lib/uprofile.h
+++ b/lib/uprofile.h
@@ -16,29 +16,9 @@
 #include <string>
 #include <vector>
 
+#include "api.h"
 #include "igpumonitor.h"
 #include "timestampunit.h"
-
-// UPROFAPI is used to export public API functions from the DLL / shared library.
-#if defined(_UPROFILE_BUILD_SHARED)
-#if defined(_WIN32)
-/* Build as a Win32 DLL */
-#define UPROFAPI __declspec(dllexport)
-#elif defined(__linux__)
-/* Build as a shared library */
-#define UPROFAPI __attribute__((visibility("default")))
-#endif // if defined(_UPROFILE_BUILD_SHARED)
-
-#elif defined(UPROFILE_DLL)
-#if defined(_WIN32)
-/* Call uprofile as a Win32 DLL */
-#define UPROFAPI __declspec(dllimport)
-#endif // if defined(_WIN32)
-#endif // if defined(UPROFILE_DLL)
-
-#if !defined(UPROFAPI)
-#define UPROFAPI
-#endif
 
 /**
  * @defgroup uprofile Functions for monitoring system metrics


### PR DESCRIPTION
NVidiaMonitor symbols were not exported when cppuprofile was compiled as a shared library on Linux due to -fvisibility=hidden option.

Let's fix this by exporting the public NvidiaMonitor methods.