### PR TITLE
Fix crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,17 @@ public:
 And then inject it at runtime to the `uprofile` monitoring system:
 
 ```cpp
-uprofile::addGPUMonitor(new IGPUMonitor);
+uprofile::addGPUMonitor(new MyGPUMonitor);
 uprofile::start("uprofile.log");
 uprofile::startGPUMemoryMonitoring(200);
+uprofile::startGPUUsageMonitoring(200);
 ```
 
 #### Supported GPU monitoring
 
 Here is the list of GPUs supported by `cppuprofile`
 
-* NVidia Graphics Cards (through `nvidia-smi`). Pass `-DGPU_MONITOR_NVIDIA` as compile option and inject `uprofile::NvidiaMonitor` from `<cppuprofile/monitors/nvidiamonitor` as `GPUMonitor`. The `nvidia-smi` tool should be installed into `/usr/bin` directory.
+* NVidia Graphics Cards (through `nvidia-smi`). Pass `-DGPU_MONITOR_NVIDIA=ON` as compile option and inject `uprofile::NvidiaMonitor` from `monitors/nvidiamonitor.h` as `GPUMonitor`. The `nvidia-smi` tool should be installed into `/usr/bin` directory.
 
 ## Build
 

--- a/lib/igpumonitor.h
+++ b/lib/igpumonitor.h
@@ -34,9 +34,9 @@ public:
     virtual bool watching() const = 0;
 
     // Usage should be in percentage
-    virtual float getUsage() = 0;
+    virtual float getUsage() const = 0;
     // usedMem and totalMem should be returned as KiB
-    virtual void getMemory(int& usedMem, int& totalMem) = 0;
+    virtual void getMemory(int& usedMem, int& totalMem) const = 0;
 };
 
 }

--- a/lib/igpumonitor.h
+++ b/lib/igpumonitor.h
@@ -30,6 +30,8 @@ public:
     virtual void start(int period) = 0;
     // Stop monitoring
     virtual void stop() = 0;
+    // Return if monitor is currently watching data
+    virtual bool watching() const = 0;
 
     // Usage should be in percentage
     virtual float getUsage() = 0;

--- a/lib/monitors/nvidiamonitor.cpp
+++ b/lib/monitors/nvidiamonitor.cpp
@@ -70,13 +70,13 @@ void uprofile::NvidiaMonitor::stop()
     abortWatchGPU();
 }
 
-float uprofile::NvidiaMonitor::getUsage()
+float uprofile::NvidiaMonitor::getUsage() const
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     return m_gpuUsage;
 }
 
-void uprofile::NvidiaMonitor::getMemory(int& usedMem, int& totalMem)
+void uprofile::NvidiaMonitor::getMemory(int& usedMem, int& totalMem) const
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     usedMem = m_usedMem;

--- a/lib/monitors/nvidiamonitor.cpp
+++ b/lib/monitors/nvidiamonitor.cpp
@@ -38,7 +38,12 @@ int read_nvidia_smi_stdout(int fd, string& gpuUsage, string& usedMem, string& to
     }
 
     // Remove colon to have only spaces and use istringstream
-    line.erase(remove(line.begin(), line.end(), ','), line.end());
+    auto noSpaceEnd = remove(line.begin(), line.end(), ',');
+    if (noSpaceEnd == line.end()) { // output trace does not have comma so something went wrong with the command
+        return ENODATA;
+    }
+
+    line.erase(noSpaceEnd, line.end());
     std::istringstream ss(line);
     ss >> gpuUsage >> usedMem >> totalMem;
 

--- a/lib/monitors/nvidiamonitor.h
+++ b/lib/monitors/nvidiamonitor.h
@@ -29,15 +29,15 @@ public:
 
     UPROFAPI void start(int period) override;
     UPROFAPI void stop() override;
+    UPROFAPI bool watching() const override;
     UPROFAPI float getUsage() override;
     UPROFAPI void getMemory(int& usedMem, int& totalMem) override;
 
 private:
     void watchGPU(int period);
     void abortWatchGPU();
-    bool shouldWatch();
 
-    std::mutex m_mutex;
+    mutable std::mutex m_mutex;
     std::unique_ptr<std::thread> m_watcherThread;
     bool m_watching = false;
     int m_totalMem = 0;

--- a/lib/monitors/nvidiamonitor.h
+++ b/lib/monitors/nvidiamonitor.h
@@ -30,8 +30,8 @@ public:
     UPROFAPI void start(int period) override;
     UPROFAPI void stop() override;
     UPROFAPI bool watching() const override;
-    UPROFAPI float getUsage() override;
-    UPROFAPI void getMemory(int& usedMem, int& totalMem) override;
+    UPROFAPI float getUsage() const override;
+    UPROFAPI void getMemory(int& usedMem, int& totalMem) const override;
 
 private:
     void watchGPU(int period);

--- a/lib/uprofileimpl.cpp
+++ b/lib/uprofileimpl.cpp
@@ -189,7 +189,7 @@ void UProfileImpl::dumpCpuUsage()
 
 void UProfileImpl::dumpGpuUsage()
 {
-    if (!m_gpuMonitor) {
+    if (!m_gpuMonitor || !m_gpuMonitor->watching()) {
         return;
     }
 
@@ -199,7 +199,7 @@ void UProfileImpl::dumpGpuUsage()
 
 void UProfileImpl::dumpGpuMemory()
 {
-    if (!m_gpuMonitor) {
+    if (!m_gpuMonitor || !m_gpuMonitor->watching()) {
         return;
     }
 

--- a/lib/uprofileimpl.cpp
+++ b/lib/uprofileimpl.cpp
@@ -199,6 +199,10 @@ void UProfileImpl::dumpGpuUsage()
 
 void UProfileImpl::dumpGpuMemory()
 {
+    if (!m_gpuMonitor) {
+        return;
+    }
+
     int usedMem, totalMem;
     m_gpuMonitor->getMemory(usedMem, totalMem);
     write(ProfilingType::GPU_MEMORY, {std::to_string(usedMem), std::to_string(totalMem)});
@@ -219,8 +223,11 @@ void UProfileImpl::stop()
     m_cpuMonitorTimer.stop();
     m_gpuUsageMonitorTimer.stop();
     m_gpuMemoryMonitorTimer.stop();
-    m_gpuMonitor->stop();
+    if (m_gpuMonitor) {
+        m_gpuMonitor->stop();
+    }
     m_file.close();
+
 }
 
 void UProfileImpl::setTimestampUnit(TimestampUnit tsUnit)


### PR DESCRIPTION
* Fix segfault crash at application exit when no GPUMonitor has been registered
* Fix crash when `nvidia-smi` returns an error instead of collection of metrics (Fix #7)
* Do not collect GPU data if GPUMonitor fails to watch GPU
* Slighty change in `IGPUMonitor` APIs to make methods const