### PR TITLE
Adding the ability to monitor multiple GPUs using NvidiaMonitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ OPTION(SAMPLE_ENABLED "Whether sample binary is built or not" OFF)
 OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON)
 OPTION(GPU_MONITOR_NVIDIA "Whether NVidiaMonitor class for monitoring NVidia GPUs is compiled and embedded to the library" OFF)
 
+if (GPU_MONITOR_NVIDIA)
+  add_definitions(-DGPU_MONITOR_NVIDIA)
+endif()
+
 ADD_SUBDIRECTORY(lib)
 
 IF(SAMPLE_ENABLED)

--- a/lib/igpumonitor.h
+++ b/lib/igpumonitor.h
@@ -7,6 +7,8 @@
 //
 // Author: Cédric CHEDALEUX <cedric.chedaleux@orange.com> et al.
 
+#include <vector>
+
 #ifndef IGPUMONITOR_H_
 #define IGPUMONITOR_H_
 
@@ -34,9 +36,9 @@ public:
     virtual bool watching() const = 0;
 
     // Usage should be in percentage
-    virtual float getUsage() const = 0;
+    virtual const std::vector<float>& getUsage() const = 0;
     // usedMem and totalMem should be returned as KiB
-    virtual void getMemory(int& usedMem, int& totalMem) const = 0;
+    virtual void getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem) const = 0;
 };
 
 }

--- a/lib/monitors/nvidiamonitor.cpp
+++ b/lib/monitors/nvidiamonitor.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <sstream>
 #include <string.h>
+#include <array>
 
 #if defined(__linux__)
 #include <sys/wait.h>

--- a/lib/monitors/nvidiamonitor.h
+++ b/lib/monitors/nvidiamonitor.h
@@ -30,8 +30,8 @@ public:
     UPROFAPI void start(int period) override;
     UPROFAPI void stop() override;
     UPROFAPI bool watching() const override;
-    UPROFAPI float getUsage() const override;
-    UPROFAPI void getMemory(int& usedMem, int& totalMem) const override;
+    UPROFAPI const std::vector<float>& getUsage() const override;
+    UPROFAPI void getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem) const override;
 
 private:
     void watchGPU(int period);
@@ -40,9 +40,10 @@ private:
     mutable std::mutex m_mutex;
     std::unique_ptr<std::thread> m_watcherThread;
     bool m_watching = false;
-    int m_totalMem = 0;
-    int m_usedMem = 0;
-    float m_gpuUsage = 0.f;
+    size_t nGPUs_;
+    std::vector<int> m_totalMem;
+    std::vector<int> m_usedMem;
+    std::vector<float> m_gpuUsage;
 };
 
 }

--- a/lib/uprofileimpl.cpp
+++ b/lib/uprofileimpl.cpp
@@ -193,8 +193,10 @@ void UProfileImpl::dumpGpuUsage()
         return;
     }
 
-    float usage = m_gpuMonitor->getUsage();
-    write(ProfilingType::GPU_USAGE, {std::to_string(usage)});
+    auto const& usage = m_gpuMonitor->getUsage();
+    for (size_t i = 0; i < usage.size(); ++i) {
+        write(ProfilingType::GPU_USAGE, {std::to_string(i), std::to_string(usage[i])});
+    }
 }
 
 void UProfileImpl::dumpGpuMemory()
@@ -203,9 +205,11 @@ void UProfileImpl::dumpGpuMemory()
         return;
     }
 
-    int usedMem, totalMem;
+    std::vector<int> usedMem, totalMem;
     m_gpuMonitor->getMemory(usedMem, totalMem);
-    write(ProfilingType::GPU_MEMORY, {std::to_string(usedMem), std::to_string(totalMem)});
+    for (size_t i = 0; i < usedMem.size(); ++i) {
+        write(ProfilingType::GPU_MEMORY, {std::to_string(i), std::to_string(usedMem[i]), std::to_string(totalMem[i])});
+    }
 }
 
 vector<float> UProfileImpl::getInstantCpuUsage()

--- a/sample/main.cpp
+++ b/sample/main.cpp
@@ -11,6 +11,9 @@
 #include <stdlib.h>
 #include <thread>
 #include <uprofile.h>
+#if defined(GPU_MONITOR_NVIDIA)
+    #include <monitors/nvidiamonitor.h>
+#endif
 
 void printSystemMemory()
 {
@@ -32,6 +35,11 @@ int main(int argc, char* argv[])
     printf(")\n");
 
     // --- START MONITORING ---
+    #if defined(GPU_MONITOR_NVIDIA)
+        uprofile::addGPUMonitor(new uprofile::NvidiaMonitor);
+        uprofile::startGPUMemoryMonitoring(200);
+        uprofile::startGPUUsageMonitoring(200);
+    #endif
     uprofile::startCPUUsageMonitoring(200);
     uprofile::startSystemMemoryMonitoring(200);
     uprofile::startProcessMemoryMonitoring(200);

--- a/tools/show-graph
+++ b/tools/show-graph
@@ -48,6 +48,14 @@ def filter_dataframe(df, metric):
     """
     return df[df['metric'] == metric]
 
+def filter_dataframe_by_extra1(df, extra_1):
+    """
+    Filter the datafram by extra_1 (indicating GPU index for GPU profiling data)
+    :param df:
+    :param metric:
+    :return: Dataframe
+    """
+    return df[df['extra_1'] == extra_1]
 
 def gen_time_exec_df(df):
     """
@@ -115,7 +123,7 @@ def create_proc_mem_graphs(df):
     names = ["RSS", "Shared"]
     for index in range(2):
         yield go.Scatter(x=pd.to_datetime(df['timestamp'], unit='ms'),
-                         y=(pd.to_numeric(df["extra_{}".format(index + 1)], downcast="integer") / 1024),
+                         y=(pd.to_numeric(df["extra_{}".format(index + 2)], downcast="integer") / 1024),
                          name=names[index],
                          showlegend=True)
 
@@ -126,10 +134,13 @@ def create_gpu_mem_graphs(df):
         return None
 
     names = ["Used", "Total"]
-    for index in range(2):
-        yield go.Scatter(x=pd.to_datetime(df['timestamp'], unit='ms'),
-                         y=(pd.to_numeric(df["extra_{}".format(index + 1)], downcast="integer") / 1024),
-                         name=names[index],
+    gpus = pd.unique(df['extra_1'])
+    for gpu in gpus:
+        gpu_df = df[df['extra_1'] == gpu]
+        for index in range(2):
+            yield go.Scatter(x=pd.to_datetime(gpu_df['timestamp'], unit='ms'),
+                         y=(pd.to_numeric(df["extra_{}".format(index + 2)], downcast="integer") / 1024),
+                         name="GPU {} {}".format(gpu, names[index]),
                          showlegend=True)
 
 
@@ -138,10 +149,13 @@ def create_gpu_usage_graphs(df):
     if df.empty:
         return None
 
-    yield go.Scatter(x=pd.to_datetime(df['timestamp'], unit='ms'),
-                     y=pd.to_numeric(df['extra_1']),
-                     name="GPU usage",
-                     showlegend=True)
+    gpus = pd.unique(df['extra_1'])
+    for gpu in gpus:
+        gpu_df = df[df['extra_1'] == gpu]
+        yield go.Scatter(x=pd.to_datetime(gpu_df['timestamp'], unit='ms'),
+                         y=pd.to_numeric(gpu_df['extra_2']),
+                         name="GPU {}".format(gpu),
+                         showlegend=True)
 
 
 def build_graphs(input_file, metrics):
@@ -194,7 +208,7 @@ def build_graphs(input_file, metrics):
                 figs.update_yaxes(row=row_index, col=1, rangemode="tozero")
             elif metric == 'gpu_mem':
                 # Display gpu memory
-                for trace in create_gpu_mem_graphs(filter_dataframe(global_df, 'gpu_mem')):
+                for trace in create_gpu_mem_graphs(filter_dataframe(global_df, metric)):
                     figs.add_trace(trace, row=row_index, col=1)
                 figs.update_yaxes(row=row_index, col=1, rangemode="tozero")
             row_index += 1


### PR DESCRIPTION
Hey Cédric! 

Thanks for developing `cppuprofile`! I saw that the current `NvidiaMonitor` implementation is hardcoded for single GPUs only. Therefore, I forked and added multiple GPU support. My changes include: 

* Changing storage containers `m_totalMem`, `m_usedMem`, and `m_gpuUsage` in `NvidiaMonitor` to `std::vector`s to hold entries for multiple GPUs. 
* Augmented the `NvidiaMonitor` constructor to read in the number of available GPUs from a `/usr/bin/nvidia-smi --query-gpu=count --format=csv,noheader,nounits` call and initialize the storage containers accordingly. 
* Updated `watchGPU` to use the query `--query-gpu=index,utilization.gpu,memory.used,memory.total` instead, printing the unique (system-wide) gpu index. Furthermore, `watchGPU` will now populate the `std::vector` storage containers. 
* Updated `read_nvidia_smi_stdout` to take in an additional argument `nGPUs` indicating the number of GPUs and reading in exactly the same amount of lines from stdout including the additional `index` printed. 
* Exposed `GPU_MONITOR_NVIDIA` in the CMakeLists.txt to be usable in C++ macros
* Updated the example `main.cpp` to conduct GPU monitoring if `GPU_MONITOR_NVIDIA` was switched on during `cmake`. 
* Updated `show-graph` script to plot multiple GPU usage/memory traces. 

Let me know what you think about these changes! 

Kind regards, 
Nils