### PR TITLE
Adding multi-GPU support for Nvidia monitoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ OPTION(SAMPLE_ENABLED "Whether sample binary is built or not" OFF)
 OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON)
 OPTION(GPU_MONITOR_NVIDIA "Whether NVidiaMonitor class for monitoring NVidia GPUs is compiled and embedded to the library" OFF)
 
+if (GPU_MONITOR_NVIDIA)
+  add_definitions(-DGPU_MONITOR_NVIDIA)
+endif()
+
 ADD_SUBDIRECTORY(lib)
 
 IF(SAMPLE_ENABLED)

--- a/lib/igpumonitor.h
+++ b/lib/igpumonitor.h
@@ -29,16 +29,17 @@ public:
     virtual ~IGPUMonitor() {}
 
     // Start monitoring
-    virtual void start(int period) = 0;
+    //virtual void start(int period) = 0;
+    // virtual void start() = 0;
     // Stop monitoring
-    virtual void stop() = 0;
-    // Return if monitor is currently watching data
-    virtual bool watching() const = 0;
+    // virtual void stop() = 0;
+    // // Return if monitor is currently watching data
+    // virtual bool watching() const = 0;
 
     // Usage should be in percentage
-    virtual const std::vector<float>& getUsage() const = 0;
+    virtual const std::vector<float>& getUsage() = 0;
     // usedMem and totalMem should be returned as KiB
-    virtual void getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem) const = 0;
+    virtual void getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem) = 0;
 };
 
 }

--- a/lib/igpumonitor.h
+++ b/lib/igpumonitor.h
@@ -7,6 +7,8 @@
 //
 // Author: Cédric CHEDALEUX <cedric.chedaleux@orange.com> et al.
 
+#include <vector>
+
 #ifndef IGPUMONITOR_H_
 #define IGPUMONITOR_H_
 
@@ -34,9 +36,9 @@ public:
     virtual bool watching() const = 0;
 
     // Usage should be in percentage
-    virtual float getUsage() const = 0;
+    virtual const std::vector<float>& getUsage() const = 0;
     // usedMem and totalMem should be returned as KiB
-    virtual void getMemory(int& usedMem, int& totalMem) const = 0;
+    virtual void getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem) const = 0;
 };
 
 }

--- a/lib/igpumonitor.h
+++ b/lib/igpumonitor.h
@@ -28,14 +28,6 @@ class IGPUMonitor
 public:
     virtual ~IGPUMonitor() {}
 
-    // Start monitoring
-    //virtual void start(int period) = 0;
-    // virtual void start() = 0;
-    // Stop monitoring
-    // virtual void stop() = 0;
-    // // Return if monitor is currently watching data
-    // virtual bool watching() const = 0;
-
     // Usage should be in percentage
     virtual const std::vector<float>& getUsage() = 0;
     // usedMem and totalMem should be returned as KiB

--- a/lib/monitors/nvidiamonitor.cpp
+++ b/lib/monitors/nvidiamonitor.cpp
@@ -60,6 +60,10 @@ int read_nvidia_smi_stdout(int fd, size_t nGPUs, std::vector<string>& gpuUsage, 
         std::string gpuIdx, temp_gpuUsage, temp_usedMem, temp_totalMem;
         ss >> gpuIdx >> temp_gpuUsage >> temp_usedMem >> temp_totalMem;
         size_t idx = static_cast<size_t>(std::stoull(gpuIdx));
+        if (idx >= nGPUs) {
+            std::cerr << "GPU index out of range: " << idx << std::endl;
+            continue;  // Handle the error appropriately
+        }
         gpuUsage[idx] = temp_gpuUsage; 
         usedMem[idx] = temp_usedMem; 
         totalMem[idx] = temp_totalMem;

--- a/lib/monitors/nvidiamonitor.cpp
+++ b/lib/monitors/nvidiamonitor.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <sstream>
 #include <string.h>
+#include <array>
 
 #if defined(__linux__)
 #include <sys/wait.h>

--- a/lib/monitors/nvidiamonitor.cpp
+++ b/lib/monitors/nvidiamonitor.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 #include <memory>
+#include <array>
 
 const string errorMsg = "Failed to monitor nvidia-smi process";
 

--- a/lib/monitors/nvidiamonitor.cpp
+++ b/lib/monitors/nvidiamonitor.cpp
@@ -10,81 +10,17 @@
 #include "nvidiamonitor.h"
 
 #include <algorithm>
-#include <errno.h>
-#include <fcntl.h>
 #include <iostream>
 #include <sstream>
-#include <string.h>
-#include <array>
-
-#if defined(__linux__)
-#include <sys/wait.h>
-#include <unistd.h>
-#endif
+#include <memory>
 
 const string errorMsg = "Failed to monitor nvidia-smi process";
-
-#if defined(__linux__)
-int read_nvidia_smi_stdout(int fd, size_t nGPUs, std::vector<string>& gpuUsage, std::vector<string>& usedMem, std::vector<string>& totalMem)
-{
-    std::cout << "inside read_nvidia_smi_stdout for " << nGPUs << " GPUs" << std::endl; 
-    std::vector<string> lines;
-    string leftover;
-    string line;
-    for (size_t i = 0; i < nGPUs; ++i) { //read in one full line for every gpu in the system
-        std::cout << "GPU " << i << std::endl; 
-        char buffer[4096];
-        ssize_t count = read(fd, buffer, sizeof(buffer)); // if child process crashes, we gonna be blocked here forever
-        if (count == -1) {
-            return errno;
-        } else if (count > 0) { // there is something to read
-            string data(buffer, count);
-            data = leftover + data;  // Prepend leftover from last read (sometimes vreaks up lines...)
-
-            std::cout << "read data = " << data << std::endl;
-            size_t pos = 0;
-            while ((pos = data.find('\n')) != std::string::npos) {
-                string line = data.substr(0, pos);
-                std::cout << "reduced line = " << line << std::endl;
-                lines.push_back(line);
-                data.erase(0, pos + 1);
-            }
-            leftover = data;  // Save any remaining part for the next read
-        }        
-    }
-    for (auto& line : lines) {
-        // Remove colon to have only spaces and use istringstream
-        auto noSpaceEnd = remove(line.begin(), line.end(), ',');
-        if (noSpaceEnd == line.end()) { // output trace does not have comma so something went wrong with the command
-            return ENODATA;
-        }
-
-        line.erase(noSpaceEnd, line.end());
-        std::istringstream ss(line);
-        std::string gpuIdx, temp_gpuUsage, temp_usedMem, temp_totalMem;
-        ss >> gpuIdx >> temp_gpuUsage >> temp_usedMem >> temp_totalMem;
-        size_t idx = static_cast<size_t>(std::stoull(gpuIdx));
-        if (idx >= nGPUs) {
-            std::cerr << "GPU index out of range: " << idx << std::endl;
-            continue;  // Handle the error appropriately
-        }
-        std::cout << "Converted to metrics: " << idx << ", " << temp_gpuUsage << ", " << temp_usedMem << ", " << temp_totalMem << std::endl; 
-        gpuUsage[idx] = temp_gpuUsage; 
-        usedMem[idx] = temp_usedMem; 
-        totalMem[idx] = temp_totalMem;
-        std::cout << "Finished setting vectors!" << std::endl;
-    }   
-
-    return 0;
-}
-#endif
 
 uprofile::NvidiaMonitor::NvidiaMonitor()
 {
     //query nvidia-smi to get the number of GPUs and initialize m_totalMem, m_usedMem, and m_gpuUsage vectors 
     #if defined(__linux__)
         try {
-            std::cout << "Trying to read in number of gpus" << std::endl;
             std::array<char, 128> buffer;
             std::string result;
             std::string cmd = "/usr/bin/nvidia-smi --query-gpu=count --format=csv,noheader,nounits";
@@ -96,7 +32,6 @@ uprofile::NvidiaMonitor::NvidiaMonitor()
                 result += buffer.data();
             }
             nGPUs_ = static_cast<size_t>(std::stoull(result));
-            std::cout << "nGPUs = " << nGPUs_ << std::endl;
             m_totalMem = std::vector<int>(nGPUs_, 0);
             m_usedMem = std::vector<int>(nGPUs_, 0);
             m_gpuUsage = std::vector<float>(nGPUs_, 0.0);
@@ -107,26 +42,32 @@ uprofile::NvidiaMonitor::NvidiaMonitor()
 }
 
 uprofile::NvidiaMonitor::~NvidiaMonitor()
-{
-    // stop();
-}
+{}
 
-// void uprofile::NvidiaMonitor::start(int period)
-// {
-//     watchGPU(period);
-// }
-
-// void uprofile::NvidiaMonitor::stop()
-// {
-//     abortWatchGPU();
-// }
-
-void uprofile::NvidiaMonitor::update_gpu_data() {
+void uprofile::NvidiaMonitor::update_gpu_data(const std::vector<uprofile::NvidiaMonitor::Data>& data) {
     #if defined(__linux__)
         try {
+            //invoke nvidia-smi to collec
             std::array<char, 128> buffer;
             std::string result;
-            std::string cmd = "/usr/bin/nvidia-smi --query-gpu=index,utilization.gpu,memory.used,memory.total --format=csv,noheader,nounits";
+            std::string cmd = "/usr/bin/nvidia-smi --query-gpu=index";
+            for (auto const & d : data) {
+                switch (d) {
+                    case uprofile::NvidiaMonitor::Data::Usage: {
+                        cmd += ",utilization.gpu";
+                        break;  
+                    };
+                    case uprofile::NvidiaMonitor::Data::UsedMem: {
+                        cmd += ",memory.used";
+                        break;  
+                    };
+                    case uprofile::NvidiaMonitor::Data::TotalMem: {
+                        cmd += ",memory.total";
+                        break;  
+                    };
+                }
+            }
+            cmd += " --format=csv,noheader,nounits";   
             std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
             if (!pipe) {
                 throw std::runtime_error("popen() failed!");
@@ -148,16 +89,31 @@ void uprofile::NvidiaMonitor::update_gpu_data() {
 
                 //(2) read in element by element 
                 std::istringstream sss(line);
-                std::string gpuIdx, temp_gpuUsage, temp_usedMem, temp_totalMem; 
-                sss >> gpuIdx >> temp_gpuUsage >> temp_usedMem >> temp_totalMem; 
+                std::string gpuIdx;
+                sss >> gpuIdx; 
                 size_t idx = static_cast<size_t>(std::stoull(gpuIdx));
                 if (idx >= nGPUs_) {
                     std::cerr << "GPU index out of range: " << idx << std::endl;
                     continue;  // Handle the error appropriately
                 }
-                m_gpuUsage[idx] = !temp_gpuUsage.empty() ? stof(temp_gpuUsage) : 0.f;
-                m_usedMem[idx] = !temp_usedMem.empty() ? stoi(temp_usedMem) * 1024 : 0;    // MiB to KiB
-                m_totalMem[idx] = !temp_totalMem.empty() ? stoi(temp_totalMem) * 1024 : 0; // MiB to KiB
+                for (auto const & d : data) {
+                    std::string temp; 
+                    sss >> temp; 
+                    switch (d) {
+                        case uprofile::NvidiaMonitor::Data::Usage: {
+                            m_gpuUsage[idx] = !temp.empty() ? stof(temp) : 0.f;
+                            break;  
+                        };
+                        case uprofile::NvidiaMonitor::Data::UsedMem: {
+                            m_usedMem[idx] = !temp.empty() ? stoi(temp) * 1024 : 0;    // MiB to KiB
+                            break;  
+                        };
+                        case uprofile::NvidiaMonitor::Data::TotalMem: {
+                            m_totalMem[idx] = !temp.empty() ? stoi(temp) * 1024 : 0; // MiB to KiB
+                            break;  
+                        };
+                    }
+                }
             }
         } catch (const std::exception& err) {
             std::cerr << errorMsg << std::endl;
@@ -167,120 +123,18 @@ void uprofile::NvidiaMonitor::update_gpu_data() {
 
 const std::vector<float>& uprofile::NvidiaMonitor::getUsage()
 {
-    update_gpu_data();
+    update_gpu_data(std::vector<uprofile::NvidiaMonitor::Data>{
+        uprofile::NvidiaMonitor::Data::Usage
+    });
     return m_gpuUsage;
 }
 
 void uprofile::NvidiaMonitor::getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem)
 {
-    update_gpu_data();
+    update_gpu_data(std::vector<uprofile::NvidiaMonitor::Data>{
+        uprofile::NvidiaMonitor::Data::UsedMem, 
+        uprofile::NvidiaMonitor::Data::TotalMem
+    });
     usedMem = m_usedMem;
     totalMem = m_totalMem;
 }
-
-// void uprofile::NvidiaMonitor::watchGPU(int period) {
-//     #if defined(__linux__)
-
-//     #else
-//         cerr << errorMsg << endl;
-//     #endif
-// }
-
-// void uprofile::NvidiaMonitor::watchGPU(int period)
-// {
-//     std::cout << "Entering watchGPU" << std::endl; 
-//     if (m_watching) {
-//         return;
-//     }
-
-// #if defined(__linux__)
-//     char* args[5];
-//     args[0] = (char*)"/usr/bin/nvidia-smi";
-//     string period_arg = "-lms=" + to_string(period); // lms stands for continuous watching
-//     args[1] = (char*)period_arg.c_str();
-//     args[2] = (char*)"--query-gpu=index,utilization.gpu,memory.used,memory.total";
-//     args[3] = (char*)"--format=csv,noheader,nounits";
-//     args[4] = NULL;
-//     string output;
-//     int pipes[2];
-
-//     // Create the pipe
-//     if (pipe(pipes) == -1) {
-//         cerr << errorMsg << ": pipe creation failed" << endl;
-//         return;
-//     }
-
-//     // Create a child process for calling nvidia-smi
-//     pid_t pid = fork();
-
-//     switch (pid) {
-//     case -1: /* Error */
-//         cerr << errorMsg << ": process fork failed" << endl;
-//         return;
-//     case 0: /* We are in the child process */
-//         while ((dup2(pipes[1], STDOUT_FILENO) == -1) && (errno == EINTR)) {
-//         }
-//         close(pipes[1]);
-//         close(pipes[0]);
-//         execv(args[0], args);
-//         cerr << "Failed to execute '" << args[0] << "': " << strerror(errno) << endl; /* execl doesn't return unless there's an error */
-//         exit(1);
-//     default: /* We are in the parent process */
-//         std::cout << "+++ Inside parent" << std::endl; 
-//         int stdout_fd = pipes[0];
-
-//         // Start a thread to retrieve the child process stdout
-//         m_watching = true;
-//         std::cout << "+++ starting watcher" << std::endl; 
-//         m_watcherThread = unique_ptr<std::thread>(new thread([stdout_fd, pid, this]() {
-//             while (watching()) {
-//                 std::vector<string> gpuUsage(nGPUs_, ""), usedMem(nGPUs_, ""), totalMem(nGPUs_, "");
-//                 // if the child process crashes, an error is raised here and threads ends up
-//                 std::cout << "+++ calling read_nvidia_smi_stdout" << std::endl;
-//                 int err = read_nvidia_smi_stdout(stdout_fd, nGPUs_, gpuUsage, usedMem, totalMem);
-//                 if (err != 0) {
-//                     cerr << errorMsg << ": read_error = " << strerror(err) << endl;
-//                     unique_lock<mutex> lk(m_mutex);
-//                     m_watching = false;
-//                     lk.unlock();
-//                     break;
-//                 }
-//                 std::cout << "+++ success!" << std::endl;
-
-//                 unique_lock<mutex> lk(m_mutex);
-//                 for (size_t i = 0; i < nGPUs_; ++i) {
-//                     m_gpuUsage[i] = !gpuUsage[i].empty() ? stof(gpuUsage[i]) : 0.f;
-//                     m_usedMem[i] = !usedMem[i].empty() ? stoi(usedMem[i]) * 1024 : 0;    // MiB to KiB
-//                     m_totalMem[i] = !totalMem[i].empty() ? stoi(totalMem[i]) * 1024 : 0; // MiB to KiB
-
-//                     std::cout << "Setting m_gpuUsage[" << i << "] = " << m_gpuUsage[i] << std::endl; 
-//                     std::cout << "Setting m_usedMem[" << i << "] = " << m_usedMem[i] << std::endl; 
-//                     std::cout << "Setting m_totalMem[" << i << "] = " << m_totalMem[i] << std::endl; 
-//                 }
-//                 lk.unlock();
-//             }
-//         }));
-//     }
-// #else
-//     cerr << errorMsg << endl;
-// #endif
-// }
-
-// void uprofile::NvidiaMonitor::abortWatchGPU()
-// {
-// #if defined(__linux__)
-//     if (m_watcherThread) {
-//         unique_lock<mutex> lk(m_mutex);
-//         m_watching = false;
-//         lk.unlock();
-//         m_watcherThread->join();
-//         m_watcherThread.reset();
-//     }
-// #endif
-// }
-
-// bool uprofile::NvidiaMonitor::watching() const
-// {
-//     std::lock_guard<std::mutex> lock(m_mutex);
-//     return m_watching;
-// }

--- a/lib/monitors/nvidiamonitor.h
+++ b/lib/monitors/nvidiamonitor.h
@@ -12,9 +12,7 @@
 
 #include "api.h"
 #include "igpumonitor.h"
-#include <mutex>
 #include <string>
-#include <thread>
 #include <vector>
 
 using namespace std;
@@ -23,26 +21,20 @@ namespace uprofile
 {
 class NvidiaMonitor : public IGPUMonitor
 {
+    enum class Data {
+        Usage, TotalMem, UsedMem
+    };
+
 public:
     UPROFAPI explicit NvidiaMonitor();
     UPROFAPI virtual ~NvidiaMonitor();
 
-    // UPROFAPI void start(int period) override;
-    // void start() override;
-    // UPROFAPI void stop() override;
-    // UPROFAPI bool watching() const override;
     UPROFAPI const std::vector<float>& getUsage() override;
     UPROFAPI void getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem) override;
 
 private:
-    void update_gpu_data();
+    void update_gpu_data(const std::vector<Data>& data);
 
-    // void watchGPU(int period);
-    // void abortWatchGPU();
-
-    // mutable std::mutex m_mutex;
-    // std::unique_ptr<std::thread> m_watcherThread;
-    // bool m_watching = false;
     size_t nGPUs_;
     std::vector<int> m_totalMem;
     std::vector<int> m_usedMem;

--- a/lib/monitors/nvidiamonitor.h
+++ b/lib/monitors/nvidiamonitor.h
@@ -30,8 +30,8 @@ public:
     UPROFAPI void start(int period) override;
     UPROFAPI void stop() override;
     UPROFAPI bool watching() const override;
-    UPROFAPI float getUsage() const override;
-    UPROFAPI void getMemory(int& usedMem, int& totalMem) const override;
+    UPROFAPI const std::vector<float>& getUsage() const override;
+    UPROFAPI void getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem) const override;
 
 private:
     void watchGPU(int period);
@@ -40,9 +40,10 @@ private:
     mutable std::mutex m_mutex;
     std::unique_ptr<std::thread> m_watcherThread;
     bool m_watching = false;
-    int m_totalMem = 0;
-    int m_usedMem = 0;
-    float m_gpuUsage = 0.f;
+    size_t nGPUs_;
+    std::vector<int> m_totalMem;
+    std::vector<int> m_usedMem;
+    std::vector<float> m_gpuUsage;
 };
 
 }

--- a/lib/monitors/nvidiamonitor.h
+++ b/lib/monitors/nvidiamonitor.h
@@ -27,19 +27,22 @@ public:
     UPROFAPI explicit NvidiaMonitor();
     UPROFAPI virtual ~NvidiaMonitor();
 
-    UPROFAPI void start(int period) override;
-    UPROFAPI void stop() override;
-    UPROFAPI bool watching() const override;
-    UPROFAPI const std::vector<float>& getUsage() const override;
-    UPROFAPI void getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem) const override;
+    // UPROFAPI void start(int period) override;
+    // void start() override;
+    // UPROFAPI void stop() override;
+    // UPROFAPI bool watching() const override;
+    UPROFAPI const std::vector<float>& getUsage() override;
+    UPROFAPI void getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem) override;
 
 private:
-    void watchGPU(int period);
-    void abortWatchGPU();
+    void update_gpu_data();
 
-    mutable std::mutex m_mutex;
-    std::unique_ptr<std::thread> m_watcherThread;
-    bool m_watching = false;
+    // void watchGPU(int period);
+    // void abortWatchGPU();
+
+    // mutable std::mutex m_mutex;
+    // std::unique_ptr<std::thread> m_watcherThread;
+    // bool m_watching = false;
     size_t nGPUs_;
     std::vector<int> m_totalMem;
     std::vector<int> m_usedMem;

--- a/lib/uprofileimpl.cpp
+++ b/lib/uprofileimpl.cpp
@@ -193,8 +193,10 @@ void UProfileImpl::dumpGpuUsage()
         return;
     }
 
-    float usage = m_gpuMonitor->getUsage();
-    write(ProfilingType::GPU_USAGE, {std::to_string(usage)});
+    auto const& usage = m_gpuMonitor->getUsage();
+    for (size_t i = 0; i < usage.size(); ++i) {
+        write(ProfilingType::GPU_USAGE, {std::to_string(i), std::to_string(usage[i])});
+    }
 }
 
 void UProfileImpl::dumpGpuMemory()
@@ -203,9 +205,11 @@ void UProfileImpl::dumpGpuMemory()
         return;
     }
 
-    int usedMem, totalMem;
+    std::vector<int> usedMem, totalMem;
     m_gpuMonitor->getMemory(usedMem, totalMem);
-    write(ProfilingType::GPU_MEMORY, {std::to_string(usedMem), std::to_string(totalMem)});
+    for (size_t i = 0; i < usedMem.size(); ++i) {
+        write(ProfilingType::GPU_MEMORY, {std::to_string(i), std::to_string(usedMem[i]), std::to_string(totalMem[i])});
+    }
 }
 
 vector<float> UProfileImpl::getInstantCpuUsage()

--- a/lib/uprofileimpl.cpp
+++ b/lib/uprofileimpl.cpp
@@ -141,7 +141,7 @@ void UProfileImpl::startGPUUsageMonitoring(int period)
         return;
     }
 
-    m_gpuMonitor->start(period);
+    // m_gpuMonitor->start(period);
 
     m_gpuUsageMonitorTimer.setInterval(period);
     m_gpuUsageMonitorTimer.setTimeout([=]() {
@@ -156,7 +156,7 @@ void UProfileImpl::startGPUMemoryMonitoring(int period)
         std::cerr << "Cannot monitor GPU memory: no GPUMonitor set!" << std::endl;
         return;
     }
-    m_gpuMonitor->start(period);
+    // m_gpuMonitor->start(period);
 
     m_gpuMemoryMonitorTimer.setInterval(period);
     m_gpuMemoryMonitorTimer.setTimeout([=]() {
@@ -189,10 +189,12 @@ void UProfileImpl::dumpCpuUsage()
 
 void UProfileImpl::dumpGpuUsage()
 {
-    if (!m_gpuMonitor || !m_gpuMonitor->watching()) {
+    // if (!m_gpuMonitor || !m_gpuMonitor->watching()) {
+    //     return;
+    // }
+    if (!m_gpuMonitor) {
         return;
     }
-
     auto const& usage = m_gpuMonitor->getUsage();
     for (size_t i = 0; i < usage.size(); ++i) {
         write(ProfilingType::GPU_USAGE, {std::to_string(i), std::to_string(usage[i])});
@@ -201,10 +203,13 @@ void UProfileImpl::dumpGpuUsage()
 
 void UProfileImpl::dumpGpuMemory()
 {
-    if (!m_gpuMonitor || !m_gpuMonitor->watching()) {
+    // if (!m_gpuMonitor || !m_gpuMonitor->watching()) {
+    //     return;
+    // }
+
+    if (!m_gpuMonitor) {
         return;
     }
-
     std::vector<int> usedMem, totalMem;
     m_gpuMonitor->getMemory(usedMem, totalMem);
     for (size_t i = 0; i < usedMem.size(); ++i) {
@@ -227,9 +232,9 @@ void UProfileImpl::stop()
     m_cpuMonitorTimer.stop();
     m_gpuUsageMonitorTimer.stop();
     m_gpuMemoryMonitorTimer.stop();
-    if (m_gpuMonitor) {
-        m_gpuMonitor->stop();
-    }
+    // if (m_gpuMonitor) {
+    //     m_gpuMonitor->stop();
+    // }
     m_file.close();
 }
 

--- a/sample/main.cpp
+++ b/sample/main.cpp
@@ -11,6 +11,9 @@
 #include <stdlib.h>
 #include <thread>
 #include <uprofile.h>
+#if defined(GPU_MONITOR_NVIDIA)
+    #include <monitors/nvidiamonitor.h>
+#endif
 
 void printSystemMemory()
 {
@@ -32,6 +35,11 @@ int main(int argc, char* argv[])
     printf(")\n");
 
     // --- START MONITORING ---
+    #if defined(GPU_MONITOR_NVIDIA)
+        uprofile::addGPUMonitor(new uprofile::NvidiaMonitor);
+        uprofile::startGPUMemoryMonitoring(200);
+        uprofile::startGPUUsageMonitoring(200);
+    #endif
     uprofile::startCPUUsageMonitoring(200);
     uprofile::startSystemMemoryMonitoring(200);
     uprofile::startProcessMemoryMonitoring(200);

--- a/tools/show-graph
+++ b/tools/show-graph
@@ -48,6 +48,14 @@ def filter_dataframe(df, metric):
     """
     return df[df['metric'] == metric]
 
+def filter_dataframe_by_extra1(df, extra_1):
+    """
+    Filter the datafram by extra_1 (indicating GPU index for GPU profiling data)
+    :param df:
+    :param metric:
+    :return: Dataframe
+    """
+    return df[df['extra_1'] == extra_1]
 
 def gen_time_exec_df(df):
     """
@@ -115,7 +123,7 @@ def create_proc_mem_graphs(df):
     names = ["RSS", "Shared"]
     for index in range(2):
         yield go.Scatter(x=pd.to_datetime(df['timestamp'], unit='ms'),
-                         y=(pd.to_numeric(df["extra_{}".format(index + 1)], downcast="integer") / 1024),
+                         y=(pd.to_numeric(df["extra_{}".format(index + 2)], downcast="integer") / 1024),
                          name=names[index],
                          showlegend=True)
 
@@ -126,10 +134,13 @@ def create_gpu_mem_graphs(df):
         return None
 
     names = ["Used", "Total"]
-    for index in range(2):
-        yield go.Scatter(x=pd.to_datetime(df['timestamp'], unit='ms'),
-                         y=(pd.to_numeric(df["extra_{}".format(index + 1)], downcast="integer") / 1024),
-                         name=names[index],
+    gpus = pd.unique(df['extra_1'])
+    for gpu in gpus:
+        gpu_df = df[df['extra_1'] == gpu]
+        for index in range(2):
+            yield go.Scatter(x=pd.to_datetime(gpu_df['timestamp'], unit='ms'),
+                         y=(pd.to_numeric(df["extra_{}".format(index + 2)], downcast="integer") / 1024),
+                         name="GPU {} {}".format(gpu, names[index]),
                          showlegend=True)
 
 
@@ -138,10 +149,13 @@ def create_gpu_usage_graphs(df):
     if df.empty:
         return None
 
-    yield go.Scatter(x=pd.to_datetime(df['timestamp'], unit='ms'),
-                     y=pd.to_numeric(df['extra_1']),
-                     name="GPU usage",
-                     showlegend=True)
+    gpus = pd.unique(df['extra_1'])
+    for gpu in gpus:
+        gpu_df = df[df['extra_1'] == gpu]
+        yield go.Scatter(x=pd.to_datetime(gpu_df['timestamp'], unit='ms'),
+                         y=pd.to_numeric(gpu_df['extra_2']),
+                         name="GPU {}".format(gpu),
+                         showlegend=True)
 
 
 def build_graphs(input_file, metrics):
@@ -194,7 +208,7 @@ def build_graphs(input_file, metrics):
                 figs.update_yaxes(row=row_index, col=1, rangemode="tozero")
             elif metric == 'gpu_mem':
                 # Display gpu memory
-                for trace in create_gpu_mem_graphs(filter_dataframe(global_df, 'gpu_mem')):
+                for trace in create_gpu_mem_graphs(filter_dataframe(global_df, metric)):
                     figs.add_trace(trace, row=row_index, col=1)
                 figs.update_yaxes(row=row_index, col=1, rangemode="tozero")
             row_index += 1


### PR DESCRIPTION
This MR adds the ability to monitor multiple Nvidia GPUs through `nvidia-smi` calls. It also adds some refactoring for the `NvidiaMonitor`. In detail, the changes include 

* Exposing the cmake variable `GPU_MONITOR_NVIDIA` as a C++ macro to automatically enable GPU monitoring in the example `sample/main.cpp`. 
* Simplifying the `lib/igpumonitor.h` abstract base class to the two basic functions `getUsage` and `getMemory`. 
* The `NvidiaMonitor` was changed the most by 
  1. removing the threading via `watchGPU` to read in the `nvidia-smi` calls and changing them to simpler `popen(...)` calls with no need for forked processes.
  2. The containers to hold GPU usage, used, and total memory were changed to `std::vector`s to house monitored information for multiple GPUs. During construction of the `NvidiaMonitor` object, the number of available GPUs in the system is collected from `nvidia-smi` and the vectors are initialized. 
  3. The function `void update_gpu_data(const std::vector<uprofile::NvidiaMonitor::Data>& data)` was added to update the usage and/or memory vectors, depending on the passed data argument. 
* The watching checks for `UProfileImpl::dumpGpuUsage()` and `UProfileImpl::dumpGpuMemory()` functions were removed since they are no longer needed 
* The `show-graph` tool was updated to plot multiple GPU usage and memory. 