### PR TITLE
Support multi-GPU monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 This project provides a tiny C++ profiling library for monitoring:
 * execution time
-* CPU usage
+* CPU(s) usage
 * memory usage
-* GPU usage and memory
+* GPU(s) usage and memory
 
 This library aims at collecting metrics on embedded devices to monitor device
 performance while operating heavy tasks or booting for example. Those metrics can
@@ -69,10 +69,12 @@ To monitor a specific GPU, you must subclass `IGPUMonitor`:
 
 class MyGPUMonitor: public uprofile::IGPUMonitor {
 public:
-    float getUsage() override;
-    void getMemory(int& usedMem, int& totalMem) override;
+    const std::vector<float>& getUsage() const override;
+    void getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem) override;
 }
 ```
+
+As you can see from the interface methods, `ccpuprofile` **supports multi-gpu monitoring**.
 
 And then inject it at runtime to the `uprofile` monitoring system:
 

--- a/lib/igpumonitor.h
+++ b/lib/igpumonitor.h
@@ -10,11 +10,13 @@
 #ifndef IGPUMONITOR_H_
 #define IGPUMONITOR_H_
 
+#include <vector>
+
 namespace uprofile
 {
 
 /**
- * Interface to implement for monitoring GPU usage and memory
+ * Interface to implement for monitoring GPU(s) usage and memory
  *
  * No generic abstraction of GPU metrics exists
  * on Linux nor Windows. So specific IGPUMonitor class should
@@ -33,10 +35,10 @@ public:
     // Return if monitor is currently watching data
     virtual bool watching() const = 0;
 
-    // Usage should be in percentage
-    virtual float getUsage() const = 0;
-    // usedMem and totalMem should be returned as KiB
-    virtual void getMemory(int& usedMem, int& totalMem) const = 0;
+    // Usages should be in percentage
+    virtual const std::vector<float>& getUsage() const = 0;
+    // usedMems and totalMems should be returned as KiB
+    virtual void getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem) const = 0;
 };
 
 }

--- a/lib/monitors/nvidiamonitor.h
+++ b/lib/monitors/nvidiamonitor.h
@@ -17,8 +17,6 @@
 #include <thread>
 #include <vector>
 
-using namespace std;
-
 namespace uprofile
 {
 class NvidiaMonitor : public IGPUMonitor
@@ -30,8 +28,8 @@ public:
     UPROFAPI void start(int period) override;
     UPROFAPI void stop() override;
     UPROFAPI bool watching() const override;
-    UPROFAPI float getUsage() const override;
-    UPROFAPI void getMemory(int& usedMem, int& totalMem) const override;
+    UPROFAPI const std::vector<float>& getUsage() const override;
+    UPROFAPI void getMemory(std::vector<int>& usedMem, std::vector<int>& totalMem) const override;
 
 private:
     void watchGPU(int period);
@@ -40,9 +38,10 @@ private:
     mutable std::mutex m_mutex;
     std::unique_ptr<std::thread> m_watcherThread;
     bool m_watching = false;
-    int m_totalMem = 0;
-    int m_usedMem = 0;
-    float m_gpuUsage = 0.f;
+    std::vector<int> m_totalMems;
+    std::vector<int> m_usedMems;
+    std::vector<float> m_gpuUsages;
+    size_t m_nbGPUs = 0;
 };
 
 }

--- a/lib/uprofileimpl.cpp
+++ b/lib/uprofileimpl.cpp
@@ -190,8 +190,10 @@ void UProfileImpl::dumpGpuUsage()
         return;
     }
 
-    float usage = m_gpuMonitor->getUsage();
-    write(ProfilingType::GPU_USAGE, {std::to_string(usage)});
+    auto const& usage = m_gpuMonitor->getUsage();
+    for (size_t i = 0; i < usage.size(); ++i) {
+        write(ProfilingType::GPU_USAGE, {std::to_string(i), std::to_string(usage[i])});
+    }
 }
 
 void UProfileImpl::dumpGpuMemory()
@@ -200,9 +202,11 @@ void UProfileImpl::dumpGpuMemory()
         return;
     }
 
-    int usedMem, totalMem;
-    m_gpuMonitor->getMemory(usedMem, totalMem);
-    write(ProfilingType::GPU_MEMORY, {std::to_string(usedMem), std::to_string(totalMem)});
+    vector<int> usedMems, totalMems;
+    m_gpuMonitor->getMemory(usedMems, totalMems);
+    for (size_t i = 0; i < usedMems.size(); ++i) {
+        write(ProfilingType::GPU_MEMORY, {std::to_string(i), std::to_string(usedMems[i]), std::to_string(totalMems[i])});
+    }
 }
 
 vector<float> UProfileImpl::getInstantCpuUsage()

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -21,6 +21,10 @@ ELSE()
     add_compile_options(-Wall -Werror)
 ENDIF()
 
+IF (GPU_MONITOR_NVIDIA)
+  ADD_DEFINITIONS(-DGPU_MONITOR_NVIDIA)
+ENDIF()
+
 SET(Sample_SRCS
     main.cpp
 )

--- a/sample/main.cpp
+++ b/sample/main.cpp
@@ -11,6 +11,9 @@
 #include <stdlib.h>
 #include <thread>
 #include <uprofile.h>
+#if defined(GPU_MONITOR_NVIDIA)
+#include <monitors/nvidiamonitor.h>
+#endif
 
 void printSystemMemory()
 {
@@ -32,6 +35,11 @@ int main(int argc, char* argv[])
     printf(")\n");
 
     // --- START MONITORING ---
+#if defined(GPU_MONITOR_NVIDIA)
+    uprofile::addGPUMonitor(new uprofile::NvidiaMonitor);
+    uprofile::startGPUMemoryMonitoring(200);
+    uprofile::startGPUUsageMonitoring(200);
+#endif
     uprofile::startCPUUsageMonitoring(200);
     uprofile::startSystemMemoryMonitoring(200);
     uprofile::startProcessMemoryMonitoring(200);

--- a/tools/show-graph
+++ b/tools/show-graph
@@ -172,7 +172,10 @@ def build_graphs(input_files, metrics):
     global_df = pd.DataFrame()
     for input in input_files:
         with open(input) as f:
-            global_df = pd.concat([global_df, read(f)])
+            global_df = pd.concat([global_df, read(f)], sort=True)
+
+    # Make sure data are sorted by ascending timestamp
+    global_df.sort_values('timestamp')
 
     for index, metric in enumerate(metrics):
         row_index = index + 1

--- a/tools/show-graph
+++ b/tools/show-graph
@@ -95,7 +95,7 @@ def create_cpu_graphs(df):
 
 
 def create_sys_mem_graphs(df):
-    # 'sys_mem' metrics (format is 'mem:<timestamp>:<total>:<available>:<free>')
+    # 'sys_mem' metrics (format is 'sys_mem:<timestamp>:<total>:<available>:<free>')
     if df.empty:
         return None
 
@@ -108,7 +108,7 @@ def create_sys_mem_graphs(df):
 
 
 def create_proc_mem_graphs(df):
-    # 'proc_mem' metrics (format is 'mem:<timestamp>:<rss>:<shared>')
+    # 'proc_mem' metrics (format is 'proc_mem:<timestamp>:<rss>:<shared>')
     if df.empty:
         return None
 
@@ -121,27 +121,34 @@ def create_proc_mem_graphs(df):
 
 
 def create_gpu_mem_graphs(df):
-    # 'gpu_mem' metrics (format is 'gpu_mem:<timestamp>:<total>:<used>')
+    # 'gpu_mem' metrics (format is 'gpu_mem:<timestamp>:<gpu_number>:<total>:<used>')
     if df.empty:
         return None
 
     names = ["Used", "Total"]
-    for index in range(2):
-        yield go.Scatter(x=pd.to_datetime(df['timestamp'], unit='ms'),
-                         y=(pd.to_numeric(df["extra_{}".format(index + 1)], downcast="integer") / 1024),
-                         name=names[index],
-                         showlegend=True)
+
+    gpus = pd.unique(df['extra_1'])
+    for gpu in gpus:
+        gpu_df = df[df['extra_1'] == gpu]
+        for index in range(2):
+            yield go.Scatter(x=pd.to_datetime(gpu_df['timestamp'], unit='ms'),
+                             y=(pd.to_numeric(gpu_df["extra_{}".format(index + 2)], downcast="integer") / 1024),
+                             name="GPU {} {}".format(gpu, names[index]),
+                             showlegend=True)
 
 
 def create_gpu_usage_graphs(df):
-    # 'gpu' metrics (format is 'gpu:<timestamp>:<percentage_usage>')
+    # 'gpu' metrics (format is 'gpu:<timestamp>:<gpu_number>:<percentage_usage>')
     if df.empty:
         return None
 
-    yield go.Scatter(x=pd.to_datetime(df['timestamp'], unit='ms'),
-                     y=pd.to_numeric(df['extra_1']),
-                     name="GPU usage",
-                     showlegend=True)
+    gpus = pd.unique(df['extra_1'])
+    for gpu in gpus:
+        gpu_df = df[df['extra_1'] == gpu]
+        yield go.Scatter(x=pd.to_datetime(gpu_df['timestamp'], unit='ms'),
+                         y=pd.to_numeric(gpu_df['extra_2']),
+                         name="GPU {} usage".format(gpu),
+                         showlegend=True)
 
 
 def build_graphs(input_files, metrics):


### PR DESCRIPTION
Inspired by PR #12 from @herrnils

* Add support for monitoring multiple GPUs (usage and memory)
* Update `show-graph` tool to visualize all GPU metrics in a single view
* Enable GPU monitoring in `uprof-sample` if GPU_MONITOR_NVIDIA is set
* Fix invalid visualization in  `show-graph` tool when multiple event files are passed time-unordered
